### PR TITLE
chore: add label event to pull_request triggers

### DIFF
--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -19,9 +19,25 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     runs-on: ubuntu-latest
     steps:
+      - name: Remove PR label
+        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!')
+            }
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 name: code coverage
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   build:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,10 +19,26 @@ on:
 
 jobs:
   build:
-    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
+    if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Remove PR label
+        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!')
+            }
       - name: Setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,10 +13,13 @@
 # limitations under the License.
 
 name: lint
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   build:
+    if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
     name: lint
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,26 @@ on:
 
 jobs:
   integration:
-      if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
+      if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
       runs-on: [self-hosted, linux, x64]
       name: "integration tests (linux)"
       steps:
+        - name: Remove PR label
+          if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+          uses: actions/github-script@v5
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              try {
+                await github.rest.issues.removeLabel({
+                  name: 'tests: run',
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number
+                });
+              } catch (e) {
+                console.log('Failed to remove label. Another job may have already removed it!')
+              }
         - name: Setup Go
           uses: actions/setup-go@v3
           with:
@@ -48,7 +64,7 @@ jobs:
           run: |
             go test -v -race -cover ./tests
   build:
-      if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
+      if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
       name: "unit tests"
       runs-on: ${{ matrix.os }}
       strategy:
@@ -56,22 +72,20 @@ jobs:
           os: [macos-latest, windows-latest, ubuntu-latest]
       steps:
         - name: Remove PR label
-          if: ${{ github.event.action == 'labeled' && github.event.label.name == 'actions:run' }}
+          if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
           uses: actions/github-script@v5
           with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             script: |
               try {
                 await github.rest.issues.removeLabel({
-                  name: 'actions:run',
+                  name: 'tests: run',
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.payload.pull_request.number
                 });
               } catch (e) {
-                if (!e.message.includes('Label does not exist')) {
-                  throw e;
-                }
+                console.log('Failed to remove label. Another job may have already removed it!')
               }
         - name: Setup Go
           uses: actions/setup-go@v3

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,12 +15,14 @@
 name: tests
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
 
 jobs:
   integration:
+      if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
       runs-on: [self-hosted, linux, x64]
       name: "integration tests (linux)"
       steps:
@@ -46,12 +48,31 @@ jobs:
           run: |
             go test -v -race -cover ./tests
   build:
+      if: ${{ github.event.action != 'labeled' || github.event.label.name == 'actions:run' }}
       name: "unit tests"
       runs-on: ${{ matrix.os }}
       strategy:
         matrix:
           os: [macos-latest, windows-latest, ubuntu-latest]
       steps:
+        - name: Remove PR label
+          if: ${{ github.event.action == 'labeled' && github.event.label.name == 'actions:run' }}
+          uses: actions/github-script@v5
+          with:
+            github-token: ${{ secrets.GITHUB_TOKEN }}
+            script: |
+              try {
+                await github.rest.issues.removeLabel({
+                  name: 'run:pr',
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.payload.pull_request.number
+                });
+              } catch (e) {
+                if (!e.message.includes('Label does not exist')) {
+                  throw e;
+                }
+              }
         - name: Setup Go
           uses: actions/setup-go@v3
           with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,7 @@ jobs:
             script: |
               try {
                 await github.rest.issues.removeLabel({
-                  name: 'run:pr',
+                  name: 'actions:run',
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: context.payload.pull_request.number


### PR DESCRIPTION
Opening potential solution to running build jobs for PRs created by `github actions` bot.