### PR TITLE
fix: make Prometheus namespace optional

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,7 @@ type Command struct {
 	disableMetrics             bool
 	telemetryProject           string
 	telemetryPrefix            string
+	prometheus                 bool
 	prometheusNamespace        string
 	healthCheck                bool
 	httpPort                   string
@@ -184,8 +185,10 @@ the maximum time has passed. Defaults to 0s.`)
 		"Disable Cloud Monitoring integration (used with telemetry-project)")
 	cmd.PersistentFlags().StringVar(&c.telemetryPrefix, "telemetry-prefix", "",
 		"Prefix to use for Cloud Monitoring metrics.")
+	cmd.PersistentFlags().BoolVar(&c.prometheus, "prometheus", false,
+		"Enable Prometheus HTTP endpoint /metrics")
 	cmd.PersistentFlags().StringVar(&c.prometheusNamespace, "prometheus-namespace", "",
-		"Enable Prometheus for metric collection using the provided namespace")
+		"Use the provided Prometheus namespace for metrics")
 	cmd.PersistentFlags().StringVar(&c.httpPort, "http-port", "9090",
 		"Port for the Prometheus server to use")
 	cmd.PersistentFlags().BoolVar(&c.healthCheck, "health-check", false,
@@ -247,8 +250,8 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 		cmd.logger.Infof("Using API Endpoint %v", conf.APIEndpointURL)
 	}
 
-	if userHasSet("http-port") && !userHasSet("prometheus-namespace") && !userHasSet("health-check") {
-		cmd.logger.Infof("Ignoring --http-port because --prometheus-namespace or --health-check was not set")
+	if userHasSet("http-port") && !userHasSet("prometheus") && !userHasSet("health-check") {
+		cmd.logger.Infof("Ignoring --http-port because --prometheus or --health-check was not set")
 	}
 
 	if !userHasSet("telemetry-project") && userHasSet("telemetry-prefix") {
@@ -367,7 +370,7 @@ func runSignalWrapper(cmd *Command) error {
 		needsHTTPServer bool
 		mux             = http.NewServeMux()
 	)
-	if cmd.prometheusNamespace != "" {
+	if cmd.prometheus {
 		needsHTTPServer = true
 		e, err := prometheus.NewExporter(prometheus.Options{
 			Namespace: cmd.prometheusNamespace,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -457,9 +457,7 @@ func TestPrometheusMetricsEndpoint(t *testing.T) {
 	// Keep the test output quiet
 	c.SilenceUsage = true
 	c.SilenceErrors = true
-	c.SetArgs([]string{
-		"--prometheus-namespace", "prometheus",
-		"my-project:my-region:my-instance"})
+	c.SetArgs([]string{"--prometheus", "my-project:my-region:my-instance"})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
This is an adaptation of https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/1280.