### PR TITLE
chore: increase wait time to ensure TCP connections

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -337,24 +337,9 @@ func TestClientCloseWaitsForActiveConnections(t *testing.T) {
 		Instances: []proxy.InstanceConnConfig{
 			{Name: "proj:region:pg"},
 		},
+		WaitOnClose: 5 * time.Second,
 	}
-
 	c, err := proxy.NewClient(context.Background(), &fakeDialer{}, testLogger, in)
-	if err != nil {
-		t.Fatalf("proxy.NewClient error: %v", err)
-	}
-	go c.Serve(context.Background(), func() {})
-
-	conn := tryTCPDial(t, "127.0.0.1:5000")
-	_ = conn.Close()
-
-	if err := c.Close(); err != nil {
-		t.Fatalf("c.Close error: %v", err)
-	}
-
-	in.WaitOnClose = time.Second
-	in.Port = 5001
-	c, err = proxy.NewClient(context.Background(), &fakeDialer{}, testLogger, in)
 	if err != nil {
 		t.Fatalf("proxy.NewClient error: %v", err)
 	}
@@ -362,7 +347,7 @@ func TestClientCloseWaitsForActiveConnections(t *testing.T) {
 
 	var open []net.Conn
 	for i := 0; i < 5; i++ {
-		conn = tryTCPDial(t, "127.0.0.1:5001")
+		conn := tryTCPDial(t, "127.0.0.1:5000")
 		open = append(open, conn)
 	}
 	defer func() {


### PR DESCRIPTION
This is port of https://github.com/GoogleCloudPlatform/cloudsql-proxy/pull/1293.