### PR TITLE
fix: support configuration of HTTP server address

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,6 +91,7 @@ type Command struct {
 	prometheus                 bool
 	prometheusNamespace        string
 	healthCheck                bool
+	httpAddress                string
 	httpPort                   string
 }
 
@@ -189,6 +190,8 @@ the maximum time has passed. Defaults to 0s.`)
 		"Enable Prometheus HTTP endpoint /metrics")
 	cmd.PersistentFlags().StringVar(&c.prometheusNamespace, "prometheus-namespace", "",
 		"Use the provided Prometheus namespace for metrics")
+	cmd.PersistentFlags().StringVar(&c.httpAddress, "http-address", "localhost",
+		"Address for Prometheus and health check server")
 	cmd.PersistentFlags().StringVar(&c.httpPort, "http-port", "9090",
 		"Port for the Prometheus server to use")
 	cmd.PersistentFlags().BoolVar(&c.healthCheck, "health-check", false,
@@ -440,7 +443,7 @@ func runSignalWrapper(cmd *Command) error {
 	// Start the HTTP server if anything requiring HTTP is specified.
 	if needsHTTPServer {
 		server := &http.Server{
-			Addr:    fmt.Sprintf("localhost:%s", cmd.httpPort),
+			Addr:    fmt.Sprintf("%s:%s", cmd.httpAddress, cmd.httpPort),
 			Handler: mux,
 		}
 		// Start the HTTP server.


### PR DESCRIPTION
In Kubernetes, the convention is to bind HTTP probes and Prometheus endpoints to 0.0.0.0 (both lo and eth0). Since people might want to run this code on a GCE VM, default to localhost, but otherwise support binding to both interfaces.

This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1365.