### PR TITLE
chore: disable bulleye arm build

### DIFF
--- a/.build/bullseye.yaml
+++ b/.build/bullseye.yaml
@@ -56,4 +56,4 @@ options:
   env:
     - DOCKER_CLI_EXPERIMENTAL=enabled
 substitutions:
-  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64,linux/arm64'
+  _DOCKER_BUILDX_PLATFORMS: 'linux/amd64'


### PR DESCRIPTION
The work to restore this is tracked here: https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/175.