### PR TITLE
fix: restore openbsd and freebsd support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,18 @@ on:
   - cron:  '0 2 * * *'
 
 jobs:
+  compilation:
+    if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"
+    name: FreeBSD and OpenBSD compilation check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: 'actions/checkout@v3'
+
+      - name: Verify FreeBSD and OpenBSD Builds
+        run: |
+          CGO_ENABLED=0 GOOS=freebsd go build
+          CGO_ENABLED=0 GOOS=openbsd go build
   integration:
     # run job on proper workflow event triggers (skip job for pull_request event from forks and only run pull_request_target for "tests: run" label)
     if: "${{ (github.event.action != 'labeled' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name) || github.event.label.name == 'tests: run' }}"

--- a/internal/proxy/fuse.go
+++ b/internal/proxy/fuse.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !openbsd && !freebsd
+// +build !windows,!openbsd,!freebsd
 
 package proxy
 

--- a/internal/proxy/fuse_freebsd.go
+++ b/internal/proxy/fuse_freebsd.go
@@ -17,21 +17,17 @@ package proxy
 import (
 	"context"
 	"errors"
-	"path/filepath"
-	"strings"
 )
 
-var errFUSENotSupported = errors.New("FUSE is not supported on Windows")
+var errFUSENotSupported = errors.New("FUSE is not supported on FreeBSD")
 
-// UnixAddress returns the Unix socket for a given instance in the provided
-// directory, by replacing all colons in the instance's name with periods.
-func UnixAddress(dir, inst string) string {
-	inst2 := strings.ReplaceAll(inst, ":", ".")
-	return filepath.Join(dir, inst2)
+// SupportsFUSE is false on FreeBSD.
+func SupportsFUSE() error {
+	return errFUSENotSupported
 }
 
 type fuseMount struct {
-	// fuseDir is always an empty string on Windows.
+	// fuseDir is always an empty string on FreeBSD.
 	fuseDir string
 }
 

--- a/internal/proxy/fuse_openbsd.go
+++ b/internal/proxy/fuse_openbsd.go
@@ -17,26 +17,17 @@ package proxy
 import (
 	"context"
 	"errors"
-	"path/filepath"
-	"strings"
 )
 
-var errFUSENotSupported = errors.New("FUSE is not supported on Windows")
+var errFUSENotSupported = errors.New("FUSE is not supported on OpenBSD")
 
-// SupportsFUSE is false on Windows.
+// SupportsFUSE is false on OpenBSD.
 func SupportsFUSE() error {
 	return errFUSENotSupported
 }
 
-// UnixAddress returns the Unix socket for a given instance in the provided
-// directory, by replacing all colons in the instance's name with periods.
-func UnixAddress(dir, inst string) string {
-	inst2 := strings.ReplaceAll(inst, ":", ".")
-	return filepath.Join(dir, inst2)
-}
-
 type fuseMount struct {
-	// fuseDir is always an empty string on Windows.
+	// fuseDir is always an empty string on OpenBSD.
 	fuseDir string
 }
 

--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !windows
-// +build !windows
+//go:build !windows && !openbsd && !freebsd
+// +build !windows,!openbsd,!freebsd
 
 package proxy
 
@@ -28,13 +28,6 @@ import (
 	"github.com/hanwen/go-fuse/v2/fs"
 	"github.com/hanwen/go-fuse/v2/fuse"
 )
-
-// UnixAddress is defined as a function to distinguish between Linux-based
-// implementations where the dir and inst and simply joins, and Windows-based
-// implementations where the inst must be further altered.
-func UnixAddress(dir, inst string) string {
-	return filepath.Join(dir, inst)
-}
 
 type socketSymlink struct {
 	socket  *socketMount

--- a/internal/proxy/unix.go
+++ b/internal/proxy/unix.go
@@ -1,0 +1,27 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package proxy
+
+import "path/filepath"
+
+// UnixAddress is defined as a function to distinguish between Unix-based
+// implementations where the dir and inst are simply joined, and Windows-based
+// implementations where the inst must be further altered.
+func UnixAddress(dir, inst string) string {
+	return filepath.Join(dir, inst)
+}


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1442.