### PR TITLE
feat: fail on startup if instance uri is invalid

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -534,13 +534,15 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 
 	var ics []proxy.InstanceConnConfig
 	for _, a := range args {
-		// Assume no query params initially
-		ic := proxy.InstanceConnConfig{
-			Name: a,
+		// split into instance uri and query parameters
+		res := strings.SplitN(a, "?", 2)
+		_, _, _, _, err := proxy.ParseInstanceURI(res[0])
+		if err != nil {
+			return newBadCommandError(fmt.Sprintf("could not parse instance uri: %q", res[0]))
 		}
+		ic := proxy.InstanceConnConfig{Name: res[0]}
 		// If there are query params, update instance config.
-		if res := strings.SplitN(a, "?", 2); len(res) > 1 {
-			ic.Name = res[0]
+		if len(res) > 1 {
 			q, err := url.ParseQuery(res[1])
 			if err != nil {
 				return newBadCommandError(fmt.Sprintf("could not parse query: %q", res[1]))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -836,7 +836,7 @@ func TestPrometheusMetricsEndpoint(t *testing.T) {
 	// Keep the test output quiet
 	c.SilenceUsage = true
 	c.SilenceErrors = true
-	c.SetArgs([]string{"--prometheus", "my-project:my-region:my-instance"})
+	c.SetArgs([]string{"--prometheus", "projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -638,6 +638,10 @@ func TestNewCommandWithErrors(t *testing.T) {
 			args: []string{},
 		},
 		{
+			desc: "when the instance uri is bogus",
+			args: []string{"projects/proj/locations/region/clusters/clust/"},
+		},
+		{
 			desc: "when the query string is bogus",
 			args: []string{"projects/proj/locations/region/clusters/clust/instances/inst?%=foo"},
 		},

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -235,7 +235,7 @@ var (
 	unixRegex = regexp.MustCompile(`([^:]+(?:-[^:]+)?)\.(.+)\.(.+)\.(.+)`)
 )
 
-// parseInstanceURI validates the instance uri is in the proper format and
+// ParseInstanceURI validates the instance uri is in the proper format and
 // returns the project, region, cluster, and instance name.
 func ParseInstanceURI(inst string) (string, string, string, string, error) {
 	m := instURIRegex.FindSubmatch([]byte(inst))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -248,7 +248,7 @@ func ParseInstanceURI(inst string) (string, string, string, string, error) {
 // UnixSocketDir returns a shorted instance connection name to prevent
 // exceeding the Unix socket length, e.g., project.region.cluster.instance
 func UnixSocketDir(dir, inst string) (string, error) {
-	project, region, cluster, name, err := ParseInstanceURI(inst)
+	project, region, cluster, name, err := ParseInstanceURI(strings.ToLower(inst))
 	if err != nil {
 		return "", err
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -237,7 +237,7 @@ var (
 
 // parseInstanceURI validates the instance uri is in the proper format and
 // returns the project, region, cluster, and instance name.
-func parseInstanceURI(inst string) (string, string, string, string, error) {
+func ParseInstanceURI(inst string) (string, string, string, string, error) {
 	m := instURIRegex.FindSubmatch([]byte(inst))
 	if m == nil {
 		return "", "", "", "", fmt.Errorf("invalid instance name: %v", inst)
@@ -248,7 +248,7 @@ func parseInstanceURI(inst string) (string, string, string, string, error) {
 // UnixSocketDir returns a shorted instance connection name to prevent
 // exceeding the Unix socket length, e.g., project.region.cluster.instance
 func UnixSocketDir(dir, inst string) (string, error) {
-	project, region, cluster, name, err := parseInstanceURI(inst)
+	project, region, cluster, name, err := ParseInstanceURI(inst)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Change Description

Parses the instance URI when the proxy starts, failing if it's not in the correct format. 


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #186