### PR TITLE
feat: use shorter instance uri when logging

### DIFF
--- a/internal/healthcheck/healthcheck_test.go
+++ b/internal/healthcheck/healthcheck_test.go
@@ -84,7 +84,7 @@ func newProxyWithParams(t *testing.T, maxConns uint64, dialer alloydb.Dialer) *p
 		Addr: proxyHost,
 		Port: proxyPort,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 		MaxConnections: maxConns,
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -245,6 +245,15 @@ func ParseInstanceURI(inst string) (string, string, string, string, error) {
 	return string(m[1]), string(m[2]), string(m[3]), string(m[4]), nil
 }
 
+// ShortInstURI shortens the instance URI into project.region.cluster.instance.
+func ShortInstURI(inst string) (string, error) {
+	p, r, c, i, err := ParseInstanceURI(inst)
+	if err != nil {
+		return "", err
+	}
+	return strings.Join([]string{p, r, c, i}, "."), nil
+}
+
 // UnixSocketDir returns a shorted instance connection name to prevent
 // exceeding the Unix socket length, e.g., project.region.cluster.instance
 func UnixSocketDir(dir, inst string) (string, error) {
@@ -345,10 +354,15 @@ func NewClient(ctx context.Context, d alloydb.Dialer, l alloydb.Logger, conf *Co
 					l.Errorf("failed to close mount: %v", mErr)
 				}
 			}
-			return nil, fmt.Errorf("[%v] Unable to mount socket: %v", inst.Name, err)
+			i, err := ShortInstURI(inst.Name)
+			if err != nil {
+				// this shouldn't happen because the inst uri is already validated by this point
+				i = inst.Name
+			}
+			return nil, fmt.Errorf("[%v] Unable to mount socket: %v", i, err)
 		}
 
-		l.Infof("[%s] Listening on %s", inst.Name, m.Addr())
+		l.Infof("[%s] Listening on %s", m.instShort, m.Addr())
 		mnts = append(mnts, m)
 	}
 
@@ -519,7 +533,7 @@ func (c *Client) serveSocketMount(_ context.Context, s *socketMount) error {
 		cConn, err := s.Accept()
 		if err != nil {
 			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-				c.logger.Errorf("[%s] Error accepting connection: %v", s.inst, err)
+				c.logger.Errorf("[%s] Error accepting connection: %v", s.instShort, err)
 				// For transient errors, wait a small amount of time to see if it resolves itself
 				time.Sleep(10 * time.Millisecond)
 				continue
@@ -528,7 +542,7 @@ func (c *Client) serveSocketMount(_ context.Context, s *socketMount) error {
 		}
 		// handle the connection in a separate goroutine
 		go func() {
-			c.logger.Infof("[%s] accepted connection from %s\n", s.inst, cConn.RemoteAddr())
+			c.logger.Infof("[%s] accepted connection from %s\n", s.instShort, cConn.RemoteAddr())
 
 			// A client has established a connection to the local socket. Before
 			// we initiate a connection to the AlloyDB backend, increment the
@@ -549,22 +563,28 @@ func (c *Client) serveSocketMount(_ context.Context, s *socketMount) error {
 
 			sConn, err := c.dialer.Dial(ctx, s.inst)
 			if err != nil {
-				c.logger.Errorf("[%s] failed to connect to instance: %v\n", s.inst, err)
+				c.logger.Errorf("[%s] failed to connect to instance: %v\n", s.instShort, err)
 				cConn.Close()
 				return
 			}
-			c.proxyConn(s.inst, cConn, sConn)
+			c.proxyConn(s.instShort, cConn, sConn)
 		}()
 	}
 }
 
 // socketMount is a tcp/unix socket that listens for an AlloyDB instance.
 type socketMount struct {
-	inst     string
-	listener net.Listener
+	inst      string
+	instShort string
+	listener  net.Listener
 }
 
 func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst InstanceConnConfig) (*socketMount, error) {
+	shortInst, err := ShortInstURI(inst.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	var (
 		// network is one of "tcp" or "unix"
 		network string
@@ -632,7 +652,11 @@ func newSocketMount(ctx context.Context, conf *Config, pc *portConfig, inst Inst
 		_ = os.Chmod(address, 0777)
 	}
 
-	m := &socketMount{inst: inst.Name, listener: ln}
+	m := &socketMount{
+		inst:      inst.Name,
+		instShort: shortInst,
+		listener:  ln,
+	}
 	return m, nil
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -266,7 +266,7 @@ func TestClientLimitsMaxConnections(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 		MaxConnections: 1,
 	}
@@ -336,7 +336,7 @@ func TestClientCloseWaitsForActiveConnections(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 		WaitOnClose: 5 * time.Second,
 	}
@@ -367,7 +367,7 @@ func TestClientClosesCleanly(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:reg:inst"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 	}
 	c, err := proxy.NewClient(context.Background(), &fakeDialer{}, testLogger, in)
@@ -389,7 +389,7 @@ func TestClosesWithError(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:reg:inst"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 	}
 	c, err := proxy.NewClient(context.Background(), &errorDialer{}, testLogger, in)
@@ -527,7 +527,7 @@ func TestClientNotifiesCallerOnServe(t *testing.T) {
 	ctx := context.Background()
 	in := &proxy.Config{
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 	}
 	c, err := proxy.NewClient(ctx, &fakeDialer{}, testLogger, in)
@@ -558,7 +558,7 @@ func TestClientConnCount(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 		MaxConnections: 10,
 	}
@@ -600,7 +600,7 @@ func TestCheckConnections(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 5000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst"},
 		},
 	}
 	d := &fakeDialer{}
@@ -623,8 +623,8 @@ func TestCheckConnections(t *testing.T) {
 		Addr: "127.0.0.1",
 		Port: 6000,
 		Instances: []proxy.InstanceConnConfig{
-			{Name: "proj:region:pg1"},
-			{Name: "proj:region:pg2"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst1"},
+			{Name: "projects/proj/locations/region/clusters/clust/instances/inst2"},
 		},
 	}
 	ed := &errorDialer{}


### PR DESCRIPTION
## Change Description

Uses "project.region.cluster.instance" instead of the full instance URI when logging for a more compact reference. 

example:
```sh
2022/12/13 23:27:56 [proj.region.clust.inst] client closed the connection
2022/12/13 23:27:56 [proj.region.clust.inst] Listening on 127.0.0.1:5000
2022/12/13 23:27:56 [proj.region.clust.inst1] Listening on 127.0.0.1:6000
2022/12/13 23:27:56 [proj.region.clust.inst2] Listening on 127.0.0.1:6001
```

Depends on #210


## Checklist

- [x] Make sure to open an issue as a 
  [bug/issue](https://github.com/GoogleCloudPlatform//issues/new/choose) 
  before writing your code!  That way we can discuss the change, evaluate 
  designs, and agree on the general idea.
- [x] Ensure the tests and linter pass
- [x] Appropriate documentation is updated (if necessary)

## Relevant issues:

- Fixes #26 