### PR TITLE
fix: return correct exit code on SIGTERM

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -26,7 +26,7 @@ var (
 
 	errSigTerm = &exitError{
 		Err:  errors.New("SIGTERM signal received"),
-		Code: 137,
+		Code: 143,
 	}
 )
 


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1530.