### PR TITLE
chore: restore missing impersonation tests

### DIFF
--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -66,8 +66,8 @@ func requirePostgresVars(t *testing.T) {
 }
 
 func postgresDSN() string {
-	return fmt.Sprintf("host=localhost user=%s password=%s database=%s sslmode=disable",
-		*alloydbUser, *alloydbPass, *alloydbDB)
+	return fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
+		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
 }
 
 func TestPostgresTCP(t *testing.T) {
@@ -82,9 +82,7 @@ func TestPostgresTCP(t *testing.T) {
 	}
 	defer cleanup()
 
-	dsn := fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
-		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
-	proxyConnTest(t, []string{*alloydbConnName}, "alloydb1", dsn)
+	proxyConnTest(t, []string{*alloydbConnName}, "alloydb1", postgresDSN())
 }
 
 func createTempDir(t *testing.T) (string, func()) {

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -76,16 +76,7 @@ func TestPostgresTCP(t *testing.T) {
 	}
 	requirePostgresVars(t)
 
-	cleanup, err := pgxv4.RegisterDriver("alloydb1")
-	if err != nil {
-		t.Fatalf("failed to register driver: %v", err)
-	}
-	defer cleanup()
-
-	// Use a DSN with the instance URI for the customer alloydb1 driver.
-	dsn := fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
-		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
-	proxyConnTest(t, []string{*alloydbConnName}, "alloydb1", dsn)
+	proxyConnTest(t, []string{*alloydbConnName}, "pgx", postgresDSN())
 }
 
 func createTempDir(t *testing.T) (string, func()) {
@@ -132,13 +123,10 @@ func TestPostgresImpersonation(t *testing.T) {
 	}
 	defer cleanup()
 
-	// Use a DSN with the instance URI for the customer alloydb1 driver.
-	dsn := fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
-		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
 	proxyConnTest(t, []string{
 		"--impersonate-service-account", *impersonatedUser,
 		*alloydbConnName},
-		"alloydb2", dsn)
+		"pgx", postgresDSN())
 }
 
 func TestPostgresAuthentication(t *testing.T) {
@@ -156,15 +144,15 @@ func TestPostgresAuthentication(t *testing.T) {
 		args []string
 	}{
 		{
+			desc: "with token",
+			args: []string{"--token", tok.AccessToken, *alloydbConnName},
+		},
+		{
 			desc: "with token and impersonation",
 			args: []string{
 				"--token", tok.AccessToken,
 				"--impersonate-service-account", *impersonatedUser,
 				*alloydbConnName},
-		},
-		{
-			desc: "with token",
-			args: []string{"--token", tok.AccessToken, *alloydbConnName},
 		},
 		{
 			desc: "with credentials file",

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -66,8 +66,8 @@ func requirePostgresVars(t *testing.T) {
 }
 
 func postgresDSN() string {
-	return fmt.Sprintf("host=%v user=%s password=%s database=%s sslmode=disable",
-		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
+	return fmt.Sprintf("host=localhost user=%s password=%s database=%s sslmode=disable",
+		*alloydbUser, *alloydbPass, *alloydbDB)
 }
 
 func TestPostgresTCP(t *testing.T) {

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -66,8 +66,8 @@ func requirePostgresVars(t *testing.T) {
 }
 
 func postgresDSN() string {
-	return fmt.Sprintf("host=localhost user=%s password=%s database=%s sslmode=disable",
-		*alloydbUser, *alloydbPass, *alloydbDB)
+	return fmt.Sprintf("host=%v user=%s password=%s database=%s sslmode=disable",
+		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
 }
 
 func TestPostgresTCP(t *testing.T) {

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -82,7 +82,10 @@ func TestPostgresTCP(t *testing.T) {
 	}
 	defer cleanup()
 
-	proxyConnTest(t, []string{*alloydbConnName}, "alloydb1", postgresDSN())
+	// Use a DSN with the instance URI for the customer alloydb1 driver.
+	dsn := fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
+		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
+	proxyConnTest(t, []string{*alloydbConnName}, "alloydb1", dsn)
 }
 
 func createTempDir(t *testing.T) (string, func()) {

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -66,8 +66,8 @@ func requirePostgresVars(t *testing.T) {
 }
 
 func postgresDSN() string {
-	return fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
-		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
+	return fmt.Sprintf("host=localhost user=%v password=%v database=%v sslmode=disable",
+		*alloydbUser, *alloydbPass, *alloydbDB)
 }
 
 func TestPostgresTCP(t *testing.T) {

--- a/tests/alloydb_test.go
+++ b/tests/alloydb_test.go
@@ -126,10 +126,19 @@ func TestPostgresImpersonation(t *testing.T) {
 	}
 	requirePostgresVars(t)
 
+	cleanup, err := pgxv4.RegisterDriver("alloydb2")
+	if err != nil {
+		t.Fatalf("failed to register driver: %v", err)
+	}
+	defer cleanup()
+
+	// Use a DSN with the instance URI for the customer alloydb1 driver.
+	dsn := fmt.Sprintf("host=%v user=%v password=%v database=%v sslmode=disable",
+		*alloydbConnName, *alloydbUser, *alloydbPass, *alloydbDB)
 	proxyConnTest(t, []string{
 		"--impersonate-service-account", *impersonatedUser,
 		*alloydbConnName},
-		"pgx", postgresDSN())
+		"alloydb2", dsn)
 }
 
 func TestPostgresAuthentication(t *testing.T) {
@@ -147,15 +156,15 @@ func TestPostgresAuthentication(t *testing.T) {
 		args []string
 	}{
 		{
-			desc: "with token",
-			args: []string{"--token", tok.AccessToken, *alloydbConnName},
-		},
-		{
 			desc: "with token and impersonation",
 			args: []string{
 				"--token", tok.AccessToken,
 				"--impersonate-service-account", *impersonatedUser,
 				*alloydbConnName},
+		},
+		{
+			desc: "with token",
+			args: []string{"--token", tok.AccessToken, *alloydbConnName},
 		},
 		{
 			desc: "with credentials file",

--- a/tests/connection_test.go
+++ b/tests/connection_test.go
@@ -70,6 +70,7 @@ func keyfile(t *testing.T) string {
 
 // proxyConnTest is a test helper to verify the proxy works with a basic connectivity test.
 func proxyConnTest(t *testing.T, args []string, driver, dsn string) {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), connTestTimeout)
 	defer cancel()
 	// Start the proxy


### PR DESCRIPTION
This commit also cleans up the authentication tests to match what we've done in the Cloud SQL Proxy.