### PR TITLE
fix: report the real error when newSocketMount() fails

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -903,7 +903,7 @@ func TestPrometheusMetricsEndpoint(t *testing.T) {
 	// Keep the test output quiet
 	c.SilenceUsage = true
 	c.SilenceErrors = true
-	c.SetArgs([]string{"--prometheus", "projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance"})
+	c.SetArgs([]string{"--prometheus", "projects/my-project/locations/my-region/clusters/my-cluster/instances/my-instance?port=5321"})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -926,7 +926,7 @@ func TestPProfServer(t *testing.T) {
 	c.SilenceUsage = true
 	c.SilenceErrors = true
 	c.SetArgs([]string{"--debug", "--admin-port", "9191",
-		"projects/proj/locations/region/clusters/clust/instances/inst"})
+		"projects/proj/locations/region/clusters/clust/instances/inst?port=5323"})
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -406,8 +406,8 @@ func NewClient(ctx context.Context, d alloydb.Dialer, l alloydb.Logger, conf *Co
 					l.Errorf("failed to close mount: %v", mErr)
 				}
 			}
-			i, instUriErr := ShortInstURI(inst.Name)
-			if instUriErr != nil {
+			i, instURIErr := ShortInstURI(inst.Name)
+			if instURIErr != nil {
 				// this shouldn't happen because the inst uri is already validated by this point
 				i = inst.Name
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -406,8 +406,8 @@ func NewClient(ctx context.Context, d alloydb.Dialer, l alloydb.Logger, conf *Co
 					l.Errorf("failed to close mount: %v", mErr)
 				}
 			}
-			i, err := ShortInstURI(inst.Name)
-			if err != nil {
+			i, instUriErr := ShortInstURI(inst.Name)
+			if instUriErr != nil {
 				// this shouldn't happen because the inst uri is already validated by this point
 				i = inst.Name
 			}


### PR DESCRIPTION
Formatting the URI into an instance name when reporting an error should not hide the real error. Also, 
avoid port conflict in root_test.go.