### PR TITLE
chore(ci): increase golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -56,3 +56,4 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+          args: --timeout 3m


### PR DESCRIPTION
Our lint job seems to be a bit flakey due to occasional timeout errors.
```
Running [/home/runner/golangci-lint-1.51.0-linux-amd64/golangci-lint run --out-format=github-actions] in [] ...
  level=error msg="Timeout exceeded: try increasing it by passing --timeout option"
```
Increasing the timeout should help reduce these errors.

Related to [#297](https://github.com/golangci/golangci-lint-action/issues/297)