### PR TITLE
chore: show all errors in proxy tests

### DIFF
--- a/tests/common_test.go
+++ b/tests/common_test.go
@@ -114,14 +114,19 @@ func (p *ProxyExec) WaitForServe(ctx context.Context) (string, error) {
 	for {
 		select {
 		case <-ctx.Done():
-			return "", ctx.Err()
+			// dump all output and return it as an error
+			all, err := io.ReadAll(in)
+			if err != nil {
+				return "", err
+			}
+			return "", errors.New(string(all))
 		default:
 		}
 		s, err := in.ReadString('\n')
 		if err != nil {
 			return "", err
 		}
-		if strings.Contains(s, "Error") {
+		if strings.Contains(s, "Error") || strings.Contains(s, "error") {
 			return "", errors.New(s)
 		}
 		if strings.Contains(s, "ready for new connections") {


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1656.