### PR TITLE
fix: honor request context in readiness check

### DIFF
--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -70,7 +70,7 @@ var errNotStarted = errors.New("proxy is not started")
 // that the proxy has not reached maximum connections, and that all connections
 // are healthy.
 func (c *Check) HandleReadiness(w http.ResponseWriter, req *http.Request) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(req.Context())
 	defer cancel()
 
 	select {


### PR DESCRIPTION
This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1657.