### PR TITLE
fix: allow `--structured-logs` and `--quiet` flags together

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -344,9 +344,8 @@ func NewCommand(opts ...Option) *Command {
 		}
 		// Handle logger separately from config
 		if c.conf.StructuredLogs {
-			c.logger, c.cleanup = log.NewStructuredLogger()
-		}
-		if c.conf.Quiet {
+			c.logger, c.cleanup = log.NewStructuredLogger(c.conf.Quiet)
+		} else if c.conf.Quiet {
 			c.logger = log.NewStdLogger(io.Discard, os.Stderr)
 		}
 		err := parseConfig(c, c.conf, args)
@@ -782,9 +781,9 @@ func runSignalWrapper(cmd *Command) (err error) {
 	err = <-shutdownCh
 	switch {
 	case errors.Is(err, errSigInt):
-		cmd.logger.Errorf("SIGINT signal received. Shutting down...")
+		cmd.logger.Infof("SIGINT signal received. Shutting down...")
 	case errors.Is(err, errSigTerm):
-		cmd.logger.Errorf("SIGTERM signal received. Shutting down...")
+		cmd.logger.Infof("SIGTERM signal received. Shutting down...")
 	default:
 		cmd.logger.Errorf("The proxy has encountered a terminal error: %v", err)
 	}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -76,7 +76,7 @@ func (l *StructuredLogger) Debugf(format string, v ...interface{}) {
 }
 
 // NewStructuredLogger creates a Logger that logs messages using JSON.
-func NewStructuredLogger() (alloydb.Logger, func() error) {
+func NewStructuredLogger(quiet bool) (alloydb.Logger, func() error) {
 	// Configure structured logs to adhere to LogEntry format
 	// https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry
 	c := zap.NewProductionEncoderConfig()
@@ -87,8 +87,16 @@ func NewStructuredLogger() (alloydb.Logger, func() error) {
 	c.EncodeTime = zapcore.ISO8601TimeEncoder
 
 	enc := zapcore.NewJSONEncoder(c)
+
+	var syncer zapcore.WriteSyncer
+	// quiet disables writing to the info log
+	if quiet {
+		syncer = zapcore.AddSync(io.Discard)
+	} else {
+		syncer = zapcore.Lock(os.Stdout)
+	}
 	core := zapcore.NewTee(
-		zapcore.NewCore(enc, zapcore.Lock(os.Stdout), zap.LevelEnablerFunc(func(l zapcore.Level) bool {
+		zapcore.NewCore(enc, syncer, zap.LevelEnablerFunc(func(l zapcore.Level) bool {
 			// Anything below error, goes to the info log.
 			return l < zapcore.ErrorLevel
 		})),


### PR DESCRIPTION
Porting over https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1750