### PR TITLE
build: add shared tags to docker images

### DIFF
--- a/.build/release_artifacts.sh
+++ b/.build/release_artifacts.sh
@@ -44,7 +44,7 @@ gcloud builds submit --async --config .build/bullseye.yaml --substitutions _VERS
 
 # Build the binarys and upload to GCS
 gcloud builds submit --config .build/gcs_upload.yaml --substitutions _VERSION=$VERSION
-# cleam up any artifacts.json left by previous builds
+# clean up any artifacts.json left by previous builds
 gsutil rm -f gs://alloydb-auth-proxy/v$VERSION/*.json 2> /dev/null || true
 
 # Generate sha256 hashes for authentication
@@ -59,11 +59,30 @@ done
 
 tag_latest() {
     local new_version=$1
+    # strip patch version from version, x.y.z -> x.y
+    # https://stackoverflow.com/questions/49252680/bash-get-major-minor-version-from-string
+    local major_minor_version=${new_version%.*}
+    # strip minor and patch version from version, x.y.z -> x 
+    local major_version=${new_version%.*.*}
     for registry in "gcr.io" "us.gcr.io" "eu.gcr.io" "asia.gcr.io"
     do
         local base_image="$registry/alloydb-connectors/alloydb-auth-proxy"
         echo "Tagging $new_version as latest in $registry"
         gcloud container images add-tag --quiet "$base_image:$new_version" "$base_image:latest"
+        gcloud container images add-tag --quiet "$base_image:$new_version" "$base_image:$major_minor_version"
+        gcloud container images add-tag --quiet "$base_image:$new_version" "$base_image:$major_version"
+        echo "Addings tags to $new_version-alpine image in $registry"
+        gcloud container images add-tag --quiet "$base_image:$new_version-alpine" "$base_image:alpine"
+        gcloud container images add-tag --quiet "$base_image:$new_version-alpine" "$base_image:$major_minor_version-alpine"
+        gcloud container images add-tag --quiet "$base_image:$new_version-alpine" "$base_image:$major_version-alpine"
+        echo "Addings tags to $new_version-buster image in $registry"
+        gcloud container images add-tag --quiet "$base_image:$new_version-buster" "$base_image:buster"
+        gcloud container images add-tag --quiet "$base_image:$new_version-buster" "$base_image:$major_minor_version-buster"
+        gcloud container images add-tag --quiet "$base_image:$new_version-buster" "$base_image:$major_version-buster"
+        echo "Addings tags to $new_version-bullseye image in $registry"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:bullseye"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_minor_version-bullseye"
+        gcloud container images add-tag --quiet "$base_image:$new_version-bullseye" "$base_image:$major_version-bullseye"
     done
 }
 


### PR DESCRIPTION
Adding additional tags to docker images.

Currently we only tag builds with a single tag such as `1.3.2-alpine`

This PR will result in additional tags such as `alpine`, `1.3-alpine`, and `1-alpine`.

The benefit is users who want to always pull the latest alpine build of the Proxy can now just pull the `alpine` tag etc.
