### PR TITLE
chore: LABEL Dockerfiles with URL of source repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+
 WORKDIR /go/src/alloydb-auth-proxy
 COPY . .
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1-alpine as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+
 WORKDIR /go/src/alloydb-auth-proxy
 COPY . .
 

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+
 WORKDIR /go/src/alloydb-auth-proxy
 COPY . .
 

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -15,6 +15,8 @@
 # Use the latest stable golang 1.x to compile to a binary
 FROM --platform=$BUILDPLATFORM golang:1 as build
 
+LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+
 WORKDIR /go/src/alloydb-auth-proxy
 COPY . .
 


### PR DESCRIPTION
Port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/2045 to add label to docker images that allows dependabot/renovate version bumps on docker images.