### PR TITLE
chore: group deps by matchManagers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,28 +14,11 @@
       "groupName": "Sample dependencies"
     },
     {
-      "matchPackagePatterns": [
-        "^actions/checkout",
-        "^actions/github-script",
-        "^actions/setup-go",
-        "^actions/upload-artifact",
-        "^dorny/paths-filter",
-        "^github/codeql-action",
-        "^golang/govulncheck-action",
-        "^golangci/golangci-lint-action",
-        "^google-github-actions/auth",
-        "^google-github-actions/get-secretmanager-secrets",
-        "^google-github-actions/setup-gcloud",
-        "^micnncim/action-label-syncer",
-        "^ossf/scorecard-action"
-      ],
+      "matchManagers": ["github-actions"],
       "groupName": "dependencies for github"
     },
     {
-      "matchPackagePatterns": [
-        "^debian:buster",
-        "^debian:bullseye"
-      ],
+      "matchManagers": ["dockerfile"],
       "groupName": "container images"
     }
   ]


### PR DESCRIPTION
Leverage https://docs.renovatebot.com/modules/manager/#managers to group dep updates.

This will allow all base image SHA bumps to be grouped.