### PR TITLE
ci: speed up pull_request builds by skipping auth

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -170,6 +170,8 @@ jobs:
 
       - id: 'auth'
         name: Authenticate to Google Cloud
+        # only needed for Flakybot on periodic (schedule) and continuous (push) events
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'push' }}
         uses: google-github-actions/auth@67e9c72af6e0492df856527b474995862b7b6591 # v2.0.0
         with:
           workload_identity_provider: ${{ secrets.PROVIDER_NAME }}


### PR DESCRIPTION
We only need `auth` step in order to run Flakybot, which does not run on pull request builds thus we can skip it.