### PR TITLE
chore: use pointer for AutoIAMAuthn instance config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -766,14 +766,14 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 // parseBoolOpt parses a boolean option from the query string.
 // True is can be "t", "true" (case-insensitive).
 // False can be "f" or "false" (case-insensitive).
-func parseBoolOpt(q url.Values, name string) (bool, error) {
+func parseBoolOpt(q url.Values, name string) (*bool, error) {
 	v, ok := q[name]
 	if !ok {
-		return false, nil
+		return nil, nil
 	}
 
 	if len(v) != 1 {
-		return false, newBadCommandError(
+		return nil, newBadCommandError(
 			fmt.Sprintf("%v param should be only one value: %q", name, v),
 		)
 	}
@@ -782,12 +782,14 @@ func parseBoolOpt(q url.Values, name string) (bool, error) {
 	// if only the key is present (and the value is empty string), accept that
 	// as true.
 	case "true", "t", "":
-		return true, nil
+		enable := true
+		return &enable, nil
 	case "false", "f":
-		return false, nil
+		disable := false
+		return &disable, nil
 	default:
 		// value is not recognized
-		return false, newBadCommandError(
+		return nil, newBadCommandError(
 			fmt.Sprintf("%v query param should be true or false, got: %q",
 				name, v[0],
 			))

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -36,6 +36,19 @@ import (
 
 const sampleURI = "projects/proj/locations/region/clusters/clust/instances/inst"
 
+// pointer returns the address of v and makes it easy to take the address of a
+// predeclared identifier. Compare:
+//
+//	t := true
+//	pt := &t
+//
+// vs
+//
+//	pt := pointer(true)
+func pointer[T any](v T) *T {
+	return &v
+}
+
 func invokeProxyCommand(args []string) (*Command, error) {
 	c := NewCommand()
 	// Keep the test output quiet
@@ -160,7 +173,7 @@ func TestNewCommandArguments(t *testing.T) {
 			},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
-					AutoIAMAuthN: true,
+					AutoIAMAuthN: pointer(true),
 					Name:         "projects/proj/locations/region/clusters/clust/instances/inst",
 				}},
 			}),
@@ -173,10 +186,10 @@ func TestNewCommandArguments(t *testing.T) {
 			},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
-					AutoIAMAuthN: true,
+					AutoIAMAuthN: pointer(true),
 					Name:         "projects/proj/locations/region/clusters/clust/instances/inst1",
 				}, {
-					AutoIAMAuthN: false,
+					AutoIAMAuthN: pointer(false),
 					Name:         "projects/proj/locations/region/clusters/clust/instances/inst2",
 				}},
 			}),
@@ -189,10 +202,10 @@ func TestNewCommandArguments(t *testing.T) {
 			},
 			want: withDefaults(&proxy.Config{
 				Instances: []proxy.InstanceConnConfig{{
-					AutoIAMAuthN: true,
+					AutoIAMAuthN: pointer(true),
 					Name:         "projects/proj/locations/region/clusters/clust/instances/inst1",
 				}, {
-					AutoIAMAuthN: false,
+					AutoIAMAuthN: pointer(false),
 					Name:         "projects/proj/locations/region/clusters/clust/instances/inst2",
 				}},
 			}),

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -59,7 +59,7 @@ type InstanceConnConfig struct {
 
 	// AutoIAMAuthN enables automatic IAM authentication on the instance only.
 	// See Config.AutoIAMAuthN for more details.
-	AutoIAMAuthN bool
+	AutoIAMAuthN *bool
 }
 
 // Config contains all the configuration provided by the caller.


### PR DESCRIPTION
Use pointer `*bool` for auto IAM authn instance config property. This will allow for unified `parseBoolOpt` for config arguments when introducing public ip.