### PR TITLE
chore: add Java Connector to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ See the [Connecting Overview][connection-overview] page for more information on
 connecting to an AlloyDB instance, or the [About the proxy][about-proxy] page
 for details on how the AlloyDB Auth Proxy works.
 
-If you're using Go, or Python, consider using the corresponding AlloyDB Connector
-which does everything the Proxy does, but in a native process:
+If you're using Go, Python, or Java consider using the corresponding AlloyDB
+Connector which does everything the Proxy does, but in a native process:
 
 - [AlloyDB Go connector][go connector]
 - [AlloyDB Python connector][python connector]
+- [AlloyDB Java connector][java connector]
 
 Note: The Proxy *cannot* provide a network path to an AlloyDB instance if one is
 not already present (e.g., the proxy cannot access a VPC if it does not already
@@ -27,6 +28,7 @@ have access to it).
 
 [go connector]: https://github.com/GoogleCloudPlatform/alloydb-go-connector
 [python connector]: https://github.com/GoogleCloudPlatform/alloydb-python-connector
+[java connector]: https://github.com/GoogleCloudPlatform/alloydb-java-connector
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ See the [Connecting Overview][connection-overview] page for more information on
 connecting to an AlloyDB instance, or the [About the proxy][about-proxy] page
 for details on how the AlloyDB Auth Proxy works.
 
-If you're using Go, Python, or Java consider using the corresponding AlloyDB
+If you're using Go, Python, or Java, consider using the corresponding AlloyDB
 Connector which does everything the Proxy does, but in a native process:
 
-- [AlloyDB Go connector][go connector]
-- [AlloyDB Python connector][python connector]
-- [AlloyDB Java connector][java connector]
+- [AlloyDB Go Connector][go connector]
+- [AlloyDB Python Connector][python connector]
+- [AlloyDB Java Connector][java connector]
 
 Note: The Proxy *cannot* provide a network path to an AlloyDB instance if one is
 not already present (e.g., the proxy cannot access a VPC if it does not already


### PR DESCRIPTION
Java Connector missing from README, adding it