### PR TITLE
chore: use json5 and group all Go nonmajor updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,11 @@
     {
       "matchManagers": ["dockerfile"],
       "groupName": "container images"
-    }
+    },
+    {
+      "groupName": "Non-major dependency updates",
+      "matchLanguages": ["go"],
+      "matchUpdateTypes": ["minor", "patch"],
+    },
   ]
 }


### PR DESCRIPTION
Fixes #599