### PR TITLE
chore: checkout PR SHA as part of running govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -37,5 +37,13 @@ jobs:
         with:
           go-version: "1.22"
           check-latest: true
+      - name: Checkout code
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: govulncheck
         uses: golang/govulncheck-action@3a32958c2706f7048305d5a2e53633d7e37e97d0 # v1
+        with:
+          # Let actions/checkout above check-out the correct SHA
+          repo-checkout: false


### PR DESCRIPTION
Previously, govulncheck was just checking out a non-PR branch and not reporting on the PR in question.