### PR TITLE
fix: switch to public mirrors of base containers

### DIFF
--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container.bullseye"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian11@sha256:97c05bb689107b51ac5c1656d8001db175ee2c214897ab6d51d74dc2a2db5023
+FROM gcr.io/cloud-marketplace-containers/google/debian11@sha256:97c05bb689107b51ac5c1656d8001db175ee2c214897ab6d51d74dc2a2db5023
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 

--- a/Dockerfile.buster
+++ b/Dockerfile.buster
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container.buster"
 
 # Final stage
-FROM gcr.io/cloud-marketplace/google/debian10@sha256:c583011c5370f62f33116fcb214de8c4665b5dc4bf40e2a9157361474647f27f
+FROM gcr.io/cloud-marketplace-containers/google/debian10@sha256:c583011c5370f62f33116fcb214de8c4665b5dc4bf40e2a9157361474647f27f
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 


### PR DESCRIPTION
The cloud-marketplace-containers project is a public mirror of cloud-marketplace. Using a public mirror makes it possible for renovate to monitor for new versions. The non-public version otherwise breaks the dependency update process.