### PR TITLE
fix: ensure graceful shutdown on fuse error

### DIFF
--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -181,6 +181,9 @@ func (c *Client) fuseMounts() []*socketMount {
 func (c *Client) unmountFUSE() error {
 	c.fuseServerMu.Lock()
 	defer c.fuseServerMu.Unlock()
+	if c.fuseServer == nil {
+		return nil
+	}
 	return c.fuseServer.Unmount()
 }
 

--- a/internal/proxy/proxy_other_test.go
+++ b/internal/proxy/proxy_other_test.go
@@ -18,8 +18,11 @@
 package proxy_test
 
 import (
+	"context"
 	"os"
 	"testing"
+
+	"github.com/GoogleCloudPlatform/alloydb-auth-proxy/internal/proxy"
 )
 
 func verifySocketPermissions(t *testing.T, addr string) {
@@ -29,5 +32,21 @@ func verifySocketPermissions(t *testing.T, addr string) {
 	}
 	if fm := fi.Mode(); fm != 0777|os.ModeSocket {
 		t.Fatalf("file mode: want = %v, got = %v", 0777|os.ModeSocket, fm)
+	}
+}
+
+func TestFuseClosesGracefully(t *testing.T) {
+	c, err := proxy.NewClient(
+		context.Background(), nil, testLogger,
+		&proxy.Config{
+			FUSEDir:     t.TempDir(),
+			FUSETempDir: t.TempDir(),
+			Token:       "mytoken",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
If the FUSE mount has not succeeded due to misconfiguration, the Proxy should still shutdown without panicing.

Related to https://github.com/GoogleCloudPlatform/cloud-sql-proxy/issues/2013