### PR TITLE
chore: Update renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,8 +22,8 @@
       "groupName": "container images"
     },
     {
+      "matchManagers": ["gomod"],
       "groupName": "Non-major dependency updates",
-      "matchLanguages": ["go"],
       "matchUpdateTypes": ["minor", "patch"],
     },
   ]


### PR DESCRIPTION
Group all Go library updates together for patch and minor versions.