### PR TITLE
feat: support static connection info

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -370,6 +370,30 @@ Third Party Licenses
   distribution please see:
 
   https://storage.googleapis.com/alloydb-auth-proxy/v1.9.0/third_party/licenses.tar.gz {x-release-please-version}
+
+Static Connection Info
+
+  In development contexts, it can be helpful to populate the Proxy with static
+  connection info. This is a *dev-only* feature and NOT for use in production.
+  The file format is subject to breaking changes.
+
+  The format is:
+
+  {
+    "publicKey": "<PEM Encoded public RSA key>",
+    "privateKey": "<PEM Encoded private RSA key>",
+    "projects/<PROJECT>/locations/<REGION>/clusters/<CLUSTER>/instances/<INSTANCE>": {
+        "ipAddress": "<PSA-based private IP address>",
+        "publicIpAddress": "<public IP address>",
+        "pscInstanceConfig": {
+            "pscDnsName": "<PSC DNS name>"
+        },
+        "pemCertificateChain": [
+            "<client cert>", "<intermediate cert>", "<CA cert>"
+        ],
+        "caCert": "<CA cert>"
+    }
+  }
 `
 
 var waitHelp = `
@@ -597,6 +621,8 @@ the cached copy has expired. Use this setting in environments where the
 CPU may be throttled and a background refresh cannot run reliably
 (e.g., Cloud Run)`,
 	)
+	localFlags.StringVar(&c.conf.StaticConnectionInfo, "static-connection-info",
+		"", "JSON file with static connection info. See --help for format.")
 
 	// Global and per instance flags
 	localFlags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -510,6 +510,17 @@ func TestNewCommandArguments(t *testing.T) {
 				DebugLogs: true,
 			}),
 		},
+		{
+			desc: "using the static connection info flag",
+			args: []string{
+				"--static-connection-info",
+				"myfile.json",
+				"projects/proj/locations/region/clusters/clust/instances/inst",
+			},
+			want: withDefaults(&proxy.Config{
+				StaticConnectionInfo: "myfile.json",
+			}),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Add support for seeding the connection info cache with static certificates and IP addresses. This is useful in development contexts and should otherwise be considered a non-production feature.

With this commit, callers may now provide the path to a JSON file which contains an RSA key pair, IP addresses, and certificate chains for any number of AlloyDB instances.

NOTE: the file format is subject to breaking changes. As such this feature should be considered for development only.