### PR TITLE
fix: ignore go-fuse ctx in Lookup

### DIFF
--- a/internal/proxy/fuse_test.go
+++ b/internal/proxy/fuse_test.go
@@ -309,7 +309,7 @@ func TestLookupIgnoresContext(t *testing.T) {
 	c, _ := newTestClient(t, d, randTmpDir(t), randTmpDir(t))
 
 	// invoke Lookup with cancelled context, should ignore context and succeed
-	_, err := c.Lookup(ctx, "proj:reg:mysql", nil)
+	_, err := c.Lookup(ctx, "proj.region.cluster.instance", nil)
 	if err != fs.OK {
 		t.Fatalf("proxy.Client.Lookup(): %v", err)
 	}

--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -99,7 +99,8 @@ func (c *Client) Readdir(_ context.Context) (fs.DirStream, syscall.Errno) {
 // socket is connected to the requested Cloud SQL instance. Lookup returns a
 // symlink (instead of the socket itself) so that multiple callers all use the
 // same Unix socket.
-func (c *Client) Lookup(ctx context.Context, instance string, _ *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+func (c *Client) Lookup(_ context.Context, instance string, _ *fuse.EntryOut) (*fs.Inode, syscall.Errno) {
+	ctx := context.Background()
 	if instance == "README" {
 		return c.NewInode(ctx, &readme{}, fs.StableAttr{}), fs.OK
 	}


### PR DESCRIPTION
Ignore context passed into `Lookup` as it can be cancelled by
interrupts in go-fuse. Instead create a new context when `Lookup`
is invoked.

Fixes #674 