### PR TITLE
feat: support for exit zero sigterm

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -29,6 +29,11 @@ var (
 		Code: 143,
 	}
 
+	errSigTermZero = &exitError{
+		Err:  errors.New("SIGTERM signal received"),
+		Code: 0,
+	}
+
 	errQuitQuitQuit = &exitError{
 		Err:  errors.New("/quitquitquit received request"),
 		Code: 0, // This error guarantees a clean exit.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -623,6 +623,8 @@ CPU may be throttled and a background refresh cannot run reliably
 	)
 	localFlags.StringVar(&c.conf.StaticConnectionInfo, "static-connection-info",
 		"", "JSON file with static connection info. See --help for format.")
+	localFlags.BoolVar(&c.conf.ExitZeroOnSigterm, "exit-zero-sigterm", false,
+		"Exit with 0 exit code when Sigterm received (default is 143)")
 
 	// Global and per instance flags
 	localFlags.StringVarP(&c.conf.Addr, "address", "a", "127.0.0.1",
@@ -1049,7 +1051,11 @@ func runSignalWrapper(cmd *Command) (err error) {
 		case syscall.SIGINT:
 			shutdownCh <- errSigInt
 		case syscall.SIGTERM:
-			shutdownCh <- errSigTerm
+			if cmd.conf.ExitZeroOnSigterm {
+				shutdownCh <- errSigTermZero
+			} else {
+				shutdownCh <- errSigTerm
+			}
 		}
 	}()
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -211,6 +211,9 @@ type Config struct {
 	// StaticConnectionInfo is the file path for a static connection info JSON
 	// file. See the proxy help message for details on its format.
 	StaticConnectionInfo string
+
+	// ExitZeroOnSigterm exits with 0 exit code when Sigterm received
+	ExitZeroOnSigterm bool
 }
 
 // dialOptions interprets appropriate dial options for a particular instance


### PR DESCRIPTION
Adds a new flag `exit-zero-on-sigterm` to exit with a 0 exit code when SIGTERM is received. This is a port of CloudSQL's `exit-on-zero-sigterm` (https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1870). Likewise, it is needed for applications that think that an exit code 143 is an error when it is not, and this provides users an easy workaround.

Fixes https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/683