### PR TITLE
chore: report disk usage in test run

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,6 +52,11 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # This helps understand how much disk space the cache and custom runner
+      # is actually using.
+      # Related to https://github.com/actions/runner/issues/2708
+      - name: Report disk usage
+        run: df -h
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:


### PR DESCRIPTION
Either the runner code doesn't clean up after itself, we're not cleaning up after ourselves, or we're just not giving the runner enough disk space. As a result, we're seeing out of space errors.

This addition will help diagnose the situation.