### PR TITLE
chore: resolve out of disk space errors

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -51,6 +51,7 @@ jobs:
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
       with:
         go-version: "1.22"
+        cache: false
       if: ${{ matrix.language == 'go' }}
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/cover.yaml
+++ b/.github/workflows/cover.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
 
       - name: Checkout base branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           go-version: "1.22"
           check-latest: true
+          cache: false
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/sample-tests.yaml
+++ b/.github/workflows/sample-tests.yaml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
       - name: Authenticate to Google Cloud
         id: 'auth'
         uses: google-github-actions/auth@f112390a2df9932162083945e46d439060d66ec2 # v2.1.4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
 
       - name: Verify FreeBSD and OpenBSD Builds
         run: |
@@ -66,6 +67,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
 
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -139,6 +141,7 @@ jobs:
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
           go-version: "1.22"
+          cache: false
 
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
The custom runner persists between runs and as a result never cleans up Go modules. As a result, the Go mod cache grows and grows and grows, which eventually results in out of disk space errors. Rather than keep bumping the disk size, this PR disables the cache such that a test run doesn't leave a big footprint behind.

Fixes #696.