### PR TITLE
chore: release-please updates the generated docs

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -19,3 +19,4 @@ versionFile: 'cmd/version.txt'
 extraFiles:
   - README.md
   - cmd/root.go
+  - docs/cmd/alloydb-auth-proxy.md


### PR DESCRIPTION
This commit ensures we don't need to manually update the version in the generated docs.