### PR TITLE
docs: remove mentions of min-ready

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -236,10 +236,7 @@ Health checks
   - /readiness: Returns 200 status when the proxy has started, has available
   connections if max connections have been set with the --max-connections
   flag, and when the proxy can connect to all registered instances. Otherwise,
-  returns a 503 status. Optionally supports a min-ready query param (e.g.,
-  /readiness?min-ready=3) where the proxy will return a 200 status if the
-  proxy can connect successfully to at least min-ready number of instances. If
-  min-ready exceeds the number of registered instances, returns a 400.
+  returns a 503 status.
 
   - /liveness: Always returns 200 status. If this endpoint is not responding,
   the proxy is in a bad state and should be restarted.

--- a/docs/cmd/alloydb-auth-proxy.md
+++ b/docs/cmd/alloydb-auth-proxy.md
@@ -131,10 +131,7 @@ Health checks
   - /readiness: Returns 200 status when the proxy has started, has available
   connections if max connections have been set with the --max-connections
   flag, and when the proxy can connect to all registered instances. Otherwise,
-  returns a 503 status. Optionally supports a min-ready query param (e.g.,
-  /readiness?min-ready=3) where the proxy will return a 200 status if the
-  proxy can connect successfully to at least min-ready number of instances. If
-  min-ready exceeds the number of registered instances, returns a 400.
+  returns a 503 status.
 
   - /liveness: Always returns 200 status. If this endpoint is not responding,
   the proxy is in a bad state and should be restarted.


### PR DESCRIPTION
Fixes #777 - removing references to `min-ready` to prevent confusion for users.