### PR TITLE
fix: quitquitquit logs info not error message

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1186,6 +1186,9 @@ func runSignalWrapper(cmd *Command) (err error) {
 	case errors.Is(err, errSigTerm):
 		cmd.logger.Infof("SIGTERM signal received. Shutting down...")
 		time.Sleep(cmd.conf.WaitBeforeClose)
+	case errors.Is(err, errQuitQuitQuit):
+		cmd.logger.Infof("/quitquitquit received request. Shutting down...")
+		time.Sleep(cmd.conf.WaitBeforeClose)
 	default:
 		cmd.logger.Errorf("The proxy has encountered a terminal error: %v", err)
 	}


### PR DESCRIPTION
This change ensures callers of /quitquitquit don't have to deal with unnecessary error logs.

This is a belated port of
https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/1806.

Fixes #802