### PR TITLE
Use Info level when /quitquitquit API is hit

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1077,7 +1077,12 @@ func runSignalWrapper(cmd *Command) (err error) {
 	var p *proxy.Client
 	select {
 	case err := <-shutdownCh:
-		cmd.logger.Errorf("The proxy has encountered a terminal error: %v", err)
+		if errors.Is(err, errQuitQuitQuit) {
+			// Intentionally using Info level log, for maintainability on GCP.
+			cmd.logger.Infof("The proxy has encountered a terminal error: %v", err)
+		} else {
+			cmd.logger.Errorf("The proxy has encountered a terminal error: %v", err)
+		}
 		// If running under systemd with Type=notify, it will send a message to the
 		// service manager that a failure occurred and it is terminating.
 		go func() {


### PR DESCRIPTION
This PR fixes https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/802 .
Related PR is https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/pull/803 .

What is reported on #802  is the following error log on GKE.
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/bbb3c586-0804-4c9c-9bd1-ee4a97b6bf87" />
