### PR TITLE
feat: add override-ip flag to override instance IP address

### DIFF
--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -120,6 +120,7 @@ func (c *Client) Lookup(_ context.Context, instance string, _ *fuse.EntryOut) (*
 	s, err := newSocketMount(
 		ctx, withUnixSocket(*c.conf, c.fuseTempDir),
 		nil, InstanceConnConfig{Name: instanceURI},
+		c.logger,
 	)
 	if err != nil {
 		c.logger.Errorf("could not create socket for %q: %v", instance, err)


### PR DESCRIPTION
This change adds a new --override-ip flag that allows users to override the IP address used to connect to AlloyDB instances. This is useful in scenarios where DNS resolution or API-returned IP addresses need to be bypassed in favor of a manually specified IP.

Changes:
- Add --override-ip global flag and per-instance query parameter support
- Implement IP address validation for override-ip values
- Add custom dial function that replaces the host with the override IP while preserving the port
- Add logging to indicate when override IP is being used
- Support override at both global level (all instances) and per-instance level (via query parameter)

The per-instance override-ip query parameter takes precedence over the global --override-ip flag, allowing fine-grained control when connecting to multiple instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)