### PR TITLE
Add override-ip flag to allow custom IP address override

### DIFF
--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -120,6 +120,7 @@ func (c *Client) Lookup(_ context.Context, instance string, _ *fuse.EntryOut) (*
 	s, err := newSocketMount(
 		ctx, withUnixSocket(*c.conf, c.fuseTempDir),
 		nil, InstanceConnConfig{Name: instanceURI},
+		c.logger,
 	)
 	if err != nil {
 		c.logger.Errorf("could not create socket for %q: %v", instance, err)


### PR DESCRIPTION
This adds support for overriding the IP address used to connect to AlloyDB instances via a new --override-ip flag and per-instance query parameter.