### PR TITLE
chore: fix lint

### DIFF
--- a/internal/proxy/fuse.go
+++ b/internal/proxy/fuse.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows && !openbsd && !freebsd
-// +build !windows,!openbsd,!freebsd
 
 package proxy
 

--- a/internal/proxy/fuse_test.go
+++ b/internal/proxy/fuse_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package proxy_test
 

--- a/internal/proxy/proxy_other.go
+++ b/internal/proxy/proxy_other.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows && !openbsd && !freebsd
-// +build !windows,!openbsd,!freebsd
 
 package proxy
 

--- a/internal/proxy/proxy_other_test.go
+++ b/internal/proxy/proxy_other_test.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package proxy_test
 

--- a/internal/proxy/unix.go
+++ b/internal/proxy/unix.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package proxy
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !windows
-// +build !windows
 
 package main
 


### PR DESCRIPTION
[Linter](https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/actions/runs/19187046681/job/55113396653?pr=844) is failing now with:

```
  Running [/home/runner/golangci-lint-2.6.1-linux-amd64/golangci-lint config path] in [/home/runner/work/alloydb-auth-proxy/alloydb-auth-proxy] ...
  Running [/home/runner/golangci-lint-2.6.1-linux-amd64/golangci-lint config verify] in [/home/runner/work/alloydb-auth-proxy/alloydb-auth-proxy] ...
  Running [/home/runner/golangci-lint-2.6.1-linux-amd64/golangci-lint run  --timeout 3m] in [/home/runner/work/alloydb-auth-proxy/alloydb-auth-proxy] ...
  Error: internal/proxy/fuse.go:16:1: buildtag: +build line is no longer needed (govet)
  // +build !windows,!openbsd,!freebsd
  ^
  Error: internal/proxy/proxy_other.go:16:1: buildtag: +build line is no longer needed (govet)
  // +build !windows,!openbsd,!freebsd
  ^
  Error: main.go:16:1: buildtag: +build line is no longer needed (govet)
  // +build !windows
  ^
  3 issues:
  * govet: 3
  
  Error: issues found
  Ran golangci-lint in 44554ms
```

This PR removes all comments with the +build line.