### PR TITLE
feat: add shutdown command

### DIFF
--- a/cmd/shutdown_test.go
+++ b/cmd/shutdown_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestShutdownCommand(t *testing.T) {
+	shutdownCh := make(chan bool, 1)
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("want = POST, got = %v", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+		shutdownCh <- true
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	_, port, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = invokeProxyCommand([]string{
+		"shutdown",
+		"--admin-port", port,
+	})
+	if err != nil {
+		t.Fatalf("invokeProxyCommand failed: %v", err)
+	}
+
+	select {
+	case <-shutdownCh:
+		// success
+	case <-time.After(1 * time.Second):
+		t.Fatal("server did not receive shutdown request")
+	}
+}
+
+func TestShutdownCommandFails(t *testing.T) {
+	_, err := invokeProxyCommand([]string{
+		"shutdown",
+		// assuming default host and port
+	})
+	if err == nil {
+		t.Fatal("shutdown should fail when endpoint does not respond")
+	}
+}

--- a/docs/cmd/alloydb-auth-proxy.md
+++ b/docs/cmd/alloydb-auth-proxy.md
@@ -359,5 +359,6 @@ alloydb-auth-proxy instance_uri... [flags]
 
 ### SEE ALSO
 
+* [alloydb-auth-proxy shutdown](alloydb-auth-proxy_shutdown.md)	 - Signal a running Proxy process to shut down
 * [alloydb-auth-proxy wait](alloydb-auth-proxy_wait.md)	 - Wait for another Proxy process to start
 

--- a/docs/cmd/alloydb-auth-proxy_shutdown.md
+++ b/docs/cmd/alloydb-auth-proxy_shutdown.md
@@ -1,0 +1,53 @@
+## alloydb-auth-proxy shutdown
+
+Signal a running Proxy process to shut down
+
+### Synopsis
+
+
+Shutting Down the Proxy
+
+  The shutdown command signals a running Proxy process to gracefully shut
+  down. This is useful for scripting and for Kubernetes environments.
+
+  The shutdown command requires that the Proxy be started in another process
+  with the admin server enabled. For example:
+
+  ./alloydb-auth-proxy <INSTANCE_URI> --quitquitquit
+
+  Invoke the shutdown command like this:
+
+  # signals another Proxy process to shut down
+  ./alloydb-auth-proxy shutdown
+
+Configuration
+
+  If the running Proxy is configured with a non-default admin port, the
+  shutdown command must also be told to use the same custom value:
+
+  ./alloydb-auth-proxy shutdown --admin-port 9192
+
+
+```
+alloydb-auth-proxy shutdown [flags]
+```
+
+### Options
+
+```
+      --admin-port string   port for the admin server (default "9091")
+  -h, --help                help for shutdown
+```
+
+### Options inherited from parent commands
+
+```
+      --http-address string   Address for Prometheus and health check server (default "localhost")
+      --http-port string      Port for the Prometheus server to use (default "9090")
+      --quiet                 Log error messages only
+```
+
+### SEE ALSO
+
+* [alloydb-auth-proxy](alloydb-auth-proxy.md)	 - alloydb-auth-proxy provides a secure way to authorize connections to AlloyDB.
+


### PR DESCRIPTION
This commit adds a shutdown command. This is useful for when callers
want to programatically stop the Auth Proxy after running database
migrations for example. By adding this command, callers need not rely
on external tools (e.g., curl and a bigger base container) and can use just
the Auth Proxy.

The shutdown command will send a request to the Auth Proxy admin
server's /quitquitquit endpoint.

This is especially useful as a preStop hook in Kubernetes. Run  the
proxy container with the --quitquitquit and --admin-port flags. Then
configure the pre-stop hook with the same admin port.

Start the Auth Proxy like this:

```
./alloydb-auth-proxy <INSTANCE_URI> --quitquitquit
```

And then shut it down with this:

```
./alloydb-auth-proxy shutdown
```

Kubernetes config looks like this:

```
lifecycle:
  preStop:
    exec:
      command: ["/alloydb-auth-proxy", "shutdown", "--admin-port", "<ADMIN_PORT>"]
```

This is a port of https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/2514.

Fixes https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/851.