### PR TITLE
fix: remove noisy permission error log

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1071,6 +1071,11 @@ func runSignalWrapper(cmd *Command) (err error) {
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
+	// Redirect gRPC's internal logger to the proxy's debug logger so that
+	// low-signal messages (e.g. monitoring.timeSeries.create permission errors)
+	// don't surface in normal output.
+	log.SetGRPCLogger(cmd.logger)
+
 	// Configure collectors before the proxy has started to ensure we are
 	// collecting metrics before *ANY* AlloyDB Admin API calls are made.
 	enableMetrics := !cmd.conf.DisableMetrics

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/oauth2 v0.35.0
 	golang.org/x/sys v0.41.0
 	google.golang.org/api v0.265.0
+	google.golang.org/grpc v1.78.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 
@@ -85,7 +86,6 @@ require (
 	google.golang.org/genproto v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260203192932-546029d2fa20 // indirect
-	google.golang.org/grpc v1.78.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
When a client runs the Auth Proxy without the time series writer permission, the Proxy emits a log message like so:

2025/04/17 19:55:33 rpc error: code = PermissionDenied desc = Permission monitoring.timeSeries.create denied (or the resource may not exist).

This commit hides this message behind the debug logger and does not let it leak into standard logs. In addition, all other grpc client logs will be redirected to the debug logger.

Fixes #787.