### PR TITLE
feat: use marketplace.gcr.io/google for Debian base images

### DIFF
--- a/Dockerfile.bookworm
+++ b/Dockerfile.bookworm
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container.bookworm"
 
 # Final stage
-FROM gcr.io/cloud-marketplace-containers/google/debian12@sha256:c9d8645e40e31ae7333adfd71a3cbd356798baed58c122831304c2ff30e279a1
+FROM marketplace.gcr.io/google/debian12@sha256:c9d8645e40e31ae7333adfd71a3cbd356798baed58c122831304c2ff30e279a1
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 
 RUN apt-get update && apt-get install -y ca-certificates

--- a/Dockerfile.bullseye
+++ b/Dockerfile.bullseye
@@ -26,7 +26,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container.bullseye"
 
 # Final stage
-FROM gcr.io/cloud-marketplace-containers/google/debian11@sha256:ef12b43cb4803b062967fb424d5bdf4d770f42b79f3b4de7a819121aee77dfdd
+FROM marketplace.gcr.io/google/debian11@sha256:ef12b43cb4803b062967fb424d5bdf4d770f42b79f3b4de7a819121aee77dfdd
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 


### PR DESCRIPTION
This is the preferred location for Google-managed Debian containers.

See https://docs.cloud.google.com/marketplace/docs/container-images.

Related to #887