### PR TITLE
fix: remove noisy error log

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,6 +44,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.opencensus.io/trace"
+	"go.opentelemetry.io/otel"
 )
 
 var (
@@ -1070,6 +1071,12 @@ func runSignalWrapper(cmd *Command) (err error) {
 	defer cmd.cleanup()
 	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
+
+	// Disable OTel's error logging for built-in metrics. For now, the errors
+	// aren't actionable and create noise in the logs.
+	// In the future, when the Auth Proxy supports customer facing OTel metrics,
+	// this should be restored to debug logs. Until then, keep the logs clean.
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(error) { /* No-op */ }))
 
 	// Configure collectors before the proxy has started to ensure we are
 	// collecting metrics before *ANY* AlloyDB Admin API calls are made.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	go.opencensus.io v0.24.0
+	go.opentelemetry.io/otel v1.42.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sys v0.42.0
 	google.golang.org/api v0.271.0
@@ -71,7 +72,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
-	go.opentelemetry.io/otel v1.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.42.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.42.0 // indirect


### PR DESCRIPTION
The Auth Proxy depends on the Go Connector which will report on internal operations using OpenTelemetry. If the exporter fails to export metrics, it would log the error, creating unactionable noise.

This commit disables the error logger, as the internal metrics are purely best effort and logs are not actionable. So this commit disables the logging.

In the future, when we add support for OpenTelemetry (as we currently have with OpenCensus), we'll need to move this error reporting to debug logs as the errors may be actionable. Until then, we'll keep the noise to a minimum.

Fixes #787.