### PR TITLE
fix: respect full config file name

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -80,7 +80,7 @@ func TestNewCommandWithConfigFile(t *testing.T) {
 		},
 		{
 			desc: "environment variable takes precedence over config file",
-			args: []string{"--config-file", "testdata/config.json"},
+			args: []string{"--config-file", "testdata/config-json.json"},
 			setup: func() {
 				t.Setenv("ALLOYDB_PROXY_INSTANCE_URI", altURI)
 			},
@@ -102,7 +102,7 @@ func TestNewCommandWithConfigFile(t *testing.T) {
 			desc: "CLI flag takes precedence over config file",
 			args: []string{
 				sampleURI,
-				"--config-file", "testdata/config.toml",
+				"--config-file", "testdata/config-toml.toml",
 				"--debug=false",
 			},
 			setup: func() {},
@@ -114,7 +114,7 @@ func TestNewCommandWithConfigFile(t *testing.T) {
 			desc: "environment variable takes precedence over config file",
 			args: []string{
 				sampleURI,
-				"--config-file", "testdata/config.toml",
+				"--config-file", "testdata/config-toml.toml",
 			},
 			setup: func() {
 				t.Setenv("ALLOYDB_PROXY_DEBUG", "false")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -784,11 +784,7 @@ func initViper(c *Command) (*viper.Viper, error) {
 			return nil, badExtErr
 		}
 
-		conf := filepath.Base(c.conf.Filepath)
-		noExt := strings.ReplaceAll(conf, ext, "")
-		// argument must be the name of config file without extension
-		v.SetConfigName(noExt)
-		v.AddConfigPath(filepath.Dir(c.conf.Filepath))
+		v.SetConfigFile(c.conf.Filepath)
 
 		// Attempt to load configuration from a file. If no file is found,
 		// assume configuration is provided by flags or environment variables.


### PR DESCRIPTION
Previously, if multiple config files were present with the same name but with different extensions, the Proxy would ignore the extension and have an implicit ordering between extensions. Now with this commit, the full config file name is respected.

Fixes #913.