### PR TITLE
chore: Update Dockerfiles and README for internal mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,25 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the latest stable golang 1.x to compile to a binary
-FROM --platform=$BUILDPLATFORM golang:1 as build
-
-WORKDIR /go/src/alloydb-auth-proxy
-COPY . .
+FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
 
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN go get ./...
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container"
-
-# Final Stage
-FROM gcr.io/distroless/static:nonroot@sha256:963fa6c544fe5ce420f1f54fb88b6fb01479f054c8056d0f74cc2c6000df5240
-
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 
-COPY --from=build --chown=nonroot /go/src/alloydb-auth-proxy/alloydb-auth-proxy /alloydb-auth-proxy
+COPY --chown=nonroot alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
 # set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 ENTRYPOINT ["/alloydb-auth-proxy"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 
-COPY --chown=nonroot alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
+COPY --chown=nonroot bin/binary/alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
 # set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 ENTRYPOINT ["/alloydb-auth-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the latest stable golang 1.x to compile to a binary
-FROM --platform=$BUILDPLATFORM golang:1-alpine as build
-
-WORKDIR /go/src/alloydb-auth-proxy
-COPY . .
+# Allow proxy to be overwritten, but hardcode the HASH to ensure it is reproducible regardless of proxy
+ARG IMAGE_NAME_WITH_PROXY=alpine
+FROM ${IMAGE_NAME_WITH_PROXY}:3@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 ARG TARGETOS
 ARG TARGETARCH
-
-RUN go get ./...
-RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    go build -ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container.alpine"
-
-# Final stage
-FROM alpine:3@sha256:a2d49ea686c2adfe3c992e47dc3b5e7fa6e6b5055609400dc2acaeb241c829f4
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
 
@@ -40,5 +31,5 @@ RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 # Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
-COPY --from=build --chown=nonroot /go/src/alloydb-auth-proxy/alloydb-auth-proxy /alloydb-auth-proxy
+COPY --chown=nonroot alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
 ENTRYPOINT ["/alloydb-auth-proxy"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -31,5 +31,5 @@ RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 # Set the uid as an integer for compatibility with runAsNonRoot in Kubernetes
 USER 65532
 
-COPY --chown=nonroot alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
+COPY --chown=nonroot bin/binary/alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
 ENTRYPOINT ["/alloydb-auth-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Registry proxy for building images
+REGISTRY_PROXY ?=
+
+BASE_IMAGE_alpine = alpine
+
+ifdef REGISTRY_PROXY
+  IMAGE_alpine = $(REGISTRY_PROXY)/$(BASE_IMAGE_alpine)
+else
+  IMAGE_alpine = $(BASE_IMAGE_alpine)
+endif
+
+# Single platform build defaults
+TARGETOS ?= linux
+TARGETARCH ?= amd64
+
+# Multi-platform build defaults
+PLATFORMS ?= linux/amd64,linux/arm64
+
+# Translate platforms (e.g. linux/amd64,linux/arm64) to binary targets (e.g. alloydb-auth-proxy.linux.amd64 alloydb-auth-proxy.linux.arm64)
+comma := ,
+PLATFORM_LIST = $(subst /,.,$(subst $(comma), ,$(PLATFORMS)))
+BINARIES = $(patsubst %, alloydb-auth-proxy.%, $(PLATFORM_LIST))
+
+# Default target
+all: build-image
+
+# Pattern rule for building binaries
+alloydb-auth-proxy.%:
+	@OS_ARCH="$*"; \
+	OS=$${OS_ARCH%%.*}; \
+	ARCH=$${OS_ARCH##*.}; \
+	echo "Building binary for $$OS/$$ARCH..."; \
+	CGO_ENABLED=0 GOOS=$$OS GOARCH=$$ARCH go build \
+		-ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container" \
+		-o $@
+
+.PHONY: build-binary
+build-binary: alloydb-auth-proxy.$(TARGETOS).$(TARGETARCH)
+
+.PHONY: build-binaries-multi
+build-binaries-multi: $(BINARIES)
+
+.PHONY: build-image
+build-image: build-binary
+	docker build \
+		--build-arg TARGETOS=$(TARGETOS) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		-t alloydb-auth-proxy:latest \
+		-f Dockerfile .
+
+.PHONY: build-image-alpine
+build-image-alpine: build-binary
+	docker build \
+		--build-arg TARGETOS=$(TARGETOS) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		--build-arg IMAGE_NAME_WITH_PROXY=$(IMAGE_alpine) \
+		-t alloydb-auth-proxy:latest-alpine \
+		-f Dockerfile.alpine .
+
+# Multi-arch build targets using docker buildx and outputs to file not docker cache
+.PHONY: build-image-multi-default
+build-image-multi-default: build-binaries-multi
+	docker buildx build \
+		--platform $(PLATFORMS) \
+  	    --output=type=oci,dest="bin/image/image-default.tar" \
+		-f Dockerfile $(BUILDX_ARGS) .
+
+.PHONY: build-image-multi-alpine
+build-image-multi-alpine: build-binaries-multi
+	docker buildx build \
+		--platform $(PLATFORMS) \
+		--build-arg IMAGE_NAME_WITH_PROXY=$(IMAGE_alpine) \
+  	    --output=type=oci,dest="bin/image/image-alpine.tar" \
+		-f Dockerfile.alpine $(BUILDX_ARGS) .
+
+.PHONY: clean
+clean:
+	rm -f alloydb-auth-proxy.*
+	rm -f bin/image/*

--- a/Makefile
+++ b/Makefile
@@ -89,5 +89,5 @@ build-image-multi-alpine: build-binaries-multi
 
 .PHONY: clean
 clean:
-	rm -f alloydb-auth-proxy.*
+	rm -f bin/binary/*
 	rm -f bin/image/*

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ alloydb-auth-proxy.%:
 	echo "Building binary for $$OS/$$ARCH..."; \
 	CGO_ENABLED=0 GOOS=$$OS GOARCH=$$ARCH go build \
 		-ldflags "-X github.com/GoogleCloudPlatform/alloydb-auth-proxy/cmd.metadataString=container" \
-		-o $@
+		-o bin/binary/$@
 
 .PHONY: build-binary
 build-binary: alloydb-auth-proxy.$(TARGETOS).$(TARGETARCH)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ psql "host=127.0.0.1 port=5432 user=DB_USER dbname=DB_NAME"
   - [Container image](#container-image)
   - [Build from source](#build-from-source)
   - [Build your own container](#build-your-own-container)
+    - [Building container images with internal mirrors](#Building-container-images-with internal-mirrors)
 - [Authentication](#authentication)
 - [Usage](#usage)
   - [Basic usage](#basic-usage)
@@ -323,11 +324,32 @@ docker run --rm \
 
 Requires the latest version of [Go](https://go.dev/doc/install).
 
+#### Using go install
+
 ```sh
 go install github.com/GoogleCloudPlatform/alloydb-auth-proxy@latest
 ```
 
 The binary is placed in `$GOPATH/bin` or `$HOME/go/bin`.
+
+#### Using the Makefile
+
+If you have cloned the repository, you can use the provided `Makefile` to build the binary.
+
+Build the binary for your current OS and architecture (defaults to `linux/amd64`):
+
+```sh
+make build-binary
+```
+
+To build for a specific OS and architecture, pass `TARGETOS` and `TARGETARCH`:
+
+```sh
+TARGETOS=darwin TARGETARCH=arm64 make build-binary
+```
+
+The binary will be created in the root directory as `alloydb-auth-proxy.<os>.<arch>` (e.g., `alloydb-auth-proxy.linux.amd64`).
+
 
 ### Build your own container
 
@@ -338,20 +360,37 @@ and target architecture.
 If you don't have a registry to push to, you can
 [set up an Artifact Registry][Artifact Registry] in Google Cloud.
 
-To build the default container:
+You should use the `Makefile` to build the container images to ensure that the go binaries are built and ready before the docker build:
 
 ```sh
-docker buildx build --platform linux/amd64 -t my-custom-image-name --push .
+# Build default container image (alloydb-auth-proxy:latest)
+make build-image
+
+# Build Alpine container image (alloydb-auth-proxy:latest-alpine)
+make build-image-alpine
 ```
 
-Alternatively, you can build the Alpine variant:
+To build multi-arch images (requires `docker buildx`):
 
 ```sh
-docker buildx build --platform linux/amd64 -t my-custom-alpine-image -f Dockerfile.alpine --push .
+# Build multi-arch default container image
+make build-image-multi-default
+
+# Build multi-arch Alpine container image
+make build-image-multi-alpine
 ```
 
 [Artifact Registry]: https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images
 [distroless]: https://github.com/GoogleContainerTools/distroless
+
+#### Building container images with internal mirrors
+
+To use an internal registry proxy for the base image when building the Alpine images, use the `REGISTRY_PROXY` variable with `make` (applies to `build-image-alpine` and `build-image-multi-alpine`):
+
+```sh
+make build-image-alpine REGISTRY_PROXY=<Reference_To_Internal_Proxy>
+make build-image-multi-alpine REGISTRY_PROXY=<Reference_To_Internal_Proxy>
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ psql "host=127.0.0.1 port=5432 user=DB_USER dbname=DB_NAME"
   - [Binary](#binary)
   - [Container image](#container-image)
   - [Build from source](#build-from-source)
+    - [Go](#using-go-install)
   - [Build your own container](#build-your-own-container)
-    - [Building container images with internal mirrors](#Building-container-images-with internal-mirrors)
+    - [Using internal mirrors](#using-internal-mirrors)
 - [Authentication](#authentication)
 - [Usage](#usage)
   - [Basic usage](#basic-usage)
@@ -348,14 +349,14 @@ To build for a specific OS and architecture, pass `TARGETOS` and `TARGETARCH`:
 TARGETOS=darwin TARGETARCH=arm64 make build-binary
 ```
 
-The binary will be created in the root directory as `alloydb-auth-proxy.<os>.<arch>` (e.g., `alloydb-auth-proxy.linux.amd64`).
+The binary will be created in the `bin/binary/` directory as `alloydb-auth-proxy.<os>.<arch>` (e.g., `alloydb-auth-proxy.linux.amd64`).
 
 
 ### Build your own container
 
 You can build and push your own container image using the provided Dockerfiles.
-These Dockerfiles require `docker buildx` to correctly set the build platform
-and target architecture.
+These Dockerfiles require `go` to build the binaries outside docker, and `docker buildx`
+to correctly set the build platform and target architecture.
 
 If you don't have a registry to push to, you can
 [set up an Artifact Registry][Artifact Registry] in Google Cloud.
@@ -383,7 +384,7 @@ make build-image-multi-alpine
 [Artifact Registry]: https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images
 [distroless]: https://github.com/GoogleContainerTools/distroless
 
-#### Building container images with internal mirrors
+#### Using internal mirrors
 
 To use an internal registry proxy for the base image when building the Alpine images, use the `REGISTRY_PROXY` variable with `make` (applies to `build-image-alpine` and `build-image-multi-alpine`):
 


### PR DESCRIPTION
Allows users to build these Dockerfiles with or without an internal mirror for golang, and docker by building the go binary outside the dockerfile and copying it in. Allows Google to use its internal mirror for building the docker image releases more securely.

Sets up a Makefile build to ensure that the binary is available before running the docker build.