### PR TITLE
chore: Fix container metadata.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+ENV ALLOYDB_PROXY_METADATA="container"
 
 COPY --chown=nonroot bin/binary/alloydb-auth-proxy.${TARGETOS}.${TARGETARCH} /alloydb-auth-proxy
 # set the uid as an integer for compatibility with runAsNonRoot in Kubernetes

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -20,6 +20,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 LABEL org.opencontainers.image.source="https://github.com/GoogleCloudPlatform/alloydb-auth-proxy"
+ENV ALLOYDB_PROXY_METADATA="container.alpine"
 
 RUN apk add --no-cache \
     ca-certificates \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,7 +65,10 @@ func init() {
 // metadata.
 func semanticVersion() string {
 	v := strings.TrimSpace(versionString)
-	if metadataString != "" {
+	osMetadata := os.Getenv("ALLOYDB_PROXY_METADATA")
+	if osMetadata != "" {
+		v += "+" + osMetadata
+	} else if metadataString != "" {
 		v += "+" + metadataString
 	}
 	return v


### PR DESCRIPTION
Since binaries are built outside of the container, use a container environment variable to detect if the binary is used in one of our built containers.