### PR TITLE
feat: add --login-token flag for separate IAM database authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ For less-common scenarios, the proxy also accepts explicit credentials via flags
 |------|-------------|
 | `--credentials-file PATH` | Path to a service account key JSON file |
 | `--token TOKEN` | An OAuth2 Bearer token |
+| `--login-token TOKEN` | A separate OAuth2 Bearer token for IAM database authentication login |
 
 **Required IAM roles** for any principal connecting through the proxy:
 
@@ -653,6 +654,7 @@ rendered docs in [docs/cmd](docs/cmd).
 | `-i, --auto-iam-authn` | false | Enable Auto IAM Authentication |
 | `-c, --credentials-file` | | Path to service account key JSON |
 | `-t, --token` | | OAuth2 Bearer token |
+| `--login-token` | | Separate token for IAM database authentication login |
 | `--public-ip` | false | Connect via public IP |
 | `--psc` | false | Connect via Private Service Connect |
 | `-u, --unix-socket` | | Directory for Unix socket listeners |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -613,7 +613,8 @@ func NewCommand(opts ...Option) *Command {
 	localFlags.StringVarP(&c.conf.Token, "token", "t", "",
 		"Bearer token used for authorization.")
 	localFlags.StringVar(&c.conf.LoginToken, "login-token", "",
-		"Bearer token used as a separate credential for IAM database authentication login. Only used when --auto-iam-authn is enabled.")
+		`Bearer token used as a separate credential for IAM database
+authentication login. Only used when --auto-iam-authn is enabled.`)
 	localFlags.StringVarP(&c.conf.CredentialsFile, "credentials-file", "c", "",
 		"Path to a service account key to use for authentication.")
 	localFlags.StringVarP(&c.conf.CredentialsJSON, "json-credentials", "j", "",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -612,6 +612,8 @@ func NewCommand(opts ...Option) *Command {
 		"Space separated list of additional user agents, e.g. custom-agent/0.0.1")
 	localFlags.StringVarP(&c.conf.Token, "token", "t", "",
 		"Bearer token used for authorization.")
+	localFlags.StringVar(&c.conf.LoginToken, "login-token", "",
+		"Bearer token used as a separate credential for IAM database authentication login. Only used when --auto-iam-authn is enabled.")
 	localFlags.StringVarP(&c.conf.CredentialsFile, "credentials-file", "c", "",
 		"Path to a service account key to use for authentication.")
 	localFlags.StringVarP(&c.conf.CredentialsJSON, "json-credentials", "j", "",
@@ -1032,6 +1034,11 @@ func parseConfig(cmd *Command, conf *proxy.Config, args []string) error {
 	}
 
 	conf.Instances = ics
+
+	if conf.LoginToken != "" && !conf.AutoIAMAuthNEnabled() {
+		cmd.logger.Infof("Ignoring --login-token because --auto-iam-authn is not enabled (globally or per-instance)")
+	}
+
 	return nil
 }
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -360,6 +360,30 @@ func TestNewCommandArguments(t *testing.T) {
 			}),
 		},
 		{
+			desc: "using the login-token flag",
+			args: []string{
+				"--auto-iam-authn",
+				"--token", "MYCOOLTOKEN",
+				"--login-token", "MYCOOLLOGINTOKEN",
+				"projects/proj/locations/region/clusters/clust/instances/inst"},
+			want: withDefaults(&proxy.Config{
+				AutoIAMAuthN: true,
+				Token:        "MYCOOLTOKEN",
+				LoginToken:   "MYCOOLLOGINTOKEN",
+			}),
+		},
+		{
+			desc: "using the login-token flag without the token flag",
+			args: []string{
+				"--auto-iam-authn",
+				"--login-token", "MYCOOLLOGINTOKEN",
+				"projects/proj/locations/region/clusters/clust/instances/inst"},
+			want: withDefaults(&proxy.Config{
+				AutoIAMAuthN: true,
+				LoginToken:   "MYCOOLLOGINTOKEN",
+			}),
+		},
+		{
 			desc: "using the credentiale file flag",
 			args: []string{"--credentials-file", "/path/to/file", "projects/proj/locations/region/clusters/clust/instances/inst"},
 			want: withDefaults(&proxy.Config{

--- a/docs/cmd/alloydb-auth-proxy.md
+++ b/docs/cmd/alloydb-auth-proxy.md
@@ -327,7 +327,8 @@ alloydb-auth-proxy instance_uri... [flags]
                                              the cached copy has expired. Use this setting in environments where the
                                              CPU may be throttled and a background refresh cannot run reliably
                                              (e.g., Cloud Run)
-      --login-token string                   Bearer token used as a separate credential for IAM database authentication login. Only used when --auto-iam-authn is enabled.
+      --login-token string                   Bearer token used as a separate credential for IAM database
+                                             authentication login. Only used when --auto-iam-authn is enabled.
       --max-connections uint                 Limits the number of connections by refusing any additional connections.
                                              When this flag is not set, there is no limit.
       --max-sigterm-delay duration           Maximum amount of time to wait after for any open connections

--- a/docs/cmd/alloydb-auth-proxy.md
+++ b/docs/cmd/alloydb-auth-proxy.md
@@ -327,6 +327,7 @@ alloydb-auth-proxy instance_uri... [flags]
                                              the cached copy has expired. Use this setting in environments where the
                                              CPU may be throttled and a background refresh cannot run reliably
                                              (e.g., Cloud Run)
+      --login-token string                   Bearer token used as a separate credential for IAM database authentication login. Only used when --auto-iam-authn is enabled.
       --max-connections uint                 Limits the number of connections by refusing any additional connections.
                                              When this flag is not set, there is no limit.
       --max-sigterm-delay duration           Maximum amount of time to wait after for any open connections

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -100,6 +100,10 @@ type Config struct {
 	// Token is the Bearer token used for authorization.
 	Token string
 
+	// LoginToken is the Bearer token scoped for IAM database authentication
+	// login.
+	LoginToken string
+
 	// CredentialsFile is the path to a service account key.
 	CredentialsFile string
 
@@ -332,9 +336,9 @@ func credentialsOpt(c Config, l alloydb.Logger) (alloydbconn.Option, error) {
 	}
 }
 
-// autoIAMAuthNEnabled returns true if IAM authentication is enabled globally
+// AutoIAMAuthNEnabled returns true if IAM authentication is enabled globally
 // or for any instance in the configuration.
-func (c *Config) autoIAMAuthNEnabled() bool {
+func (c *Config) AutoIAMAuthNEnabled() bool {
 	if c.AutoIAMAuthN {
 		return true
 	}
@@ -362,8 +366,17 @@ func (c *Config) DialerOptions(l alloydb.Logger) ([]alloydbconn.Option, error) {
 		opts = append(opts, alloydbconn.WithAdminAPIEndpoint(c.APIEndpointURL))
 	}
 
-	if c.autoIAMAuthNEnabled() {
+	if c.AutoIAMAuthNEnabled() {
 		opts = append(opts, alloydbconn.WithIAMAuthN())
+		switch {
+		case c.LoginToken != "":
+			l.Infof("Authenticating IAM database logins with the login token")
+			opts = append(opts, alloydbconn.WithIAMAuthNTokenSource(
+				oauth2.StaticTokenSource(&oauth2.Token{AccessToken: c.LoginToken}),
+			))
+		case c.Token != "" || c.ImpersonationChain != "":
+			l.Infof("Note: reusing the configured API credential for IAM database authentication login")
+		}
 	}
 
 	if c.DebugLogs {


### PR DESCRIPTION
## Overview
Adds a `--login-token` flag that lets the proxy use a separate OAuth2 token for
  IAM database authentication login, distinct from `--token`, which authenticates
  AlloyDB Admin API calls. This keeps the API credentials (Unnecessary scopes) out of the database
  login path, supporting least-privilege access.

  Requires `--token` and `--auto-iam-authn`. When unset, existing behavior is
  unchanged, and the proxy logs a warning suggesting the new flag.

Fixes https://github.com/GoogleCloudPlatform/alloydb-auth-proxy/issues/848.

  ## Testing

  - Unit tests for flag parsing and validation.
  - Verified manually against a live AlloyDB instance (public IP, IAM authn):
    - valid `--token` + valid `--login-token` → connects
    - valid `--token` + corrupted `--login-token` → rejected at the IAM check, proving no silent fallback to `--token`
    - valid `--token` only → connects via the existing fallback path, warning logged