### PR TITLE
Add the missing fork gate to the sample-tests go job (match tests.yaml integration)

### DIFF
--- a/.github/workflows/sample-tests.yaml
+++ b/.github/workflows/sample-tests.yaml
@@ -51,7 +51,15 @@ jobs:
     # This ensures that the go job executes after the changes job, since it's dependent on
     # that job's output.
     needs: changes
-    if: ${{ needs.changes.outputs.go == 'true' || github.event_name == 'schedule' }}
+    # Run the sample tests on all builds except pull requests from forks or
+    # dependabot (matches the gate on the integration job in tests.yaml): this
+    # job checks out the PR head and runs its script on a self-hosted runner
+    # with GCP credentials and a live database password in the environment, so
+    # fork-controlled code must not reach it.
+    if: |
+      (needs.changes.outputs.go == 'true' || github.event_name == 'schedule') &&
+      (github.event_name != 'pull_request' ||
+       (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'))
     runs-on: [self-hosted, linux, x64]
     permissions:
       contents: 'read'


### PR DESCRIPTION
## What this fixes

The `go` job in `.github/workflows/sample-tests.yaml` triggers on plain `pull_request` (any fork), checks out the **PR head** (`repository: ${{ github.event.pull_request.head.repo.full_name }}`, `ref: head.sha`), and executes the PR's own `examples/go/run_tests.sh` on a **self-hosted runner** after:

- `google-github-actions/auth` mints **GCP credentials** for the WIF service account (`id-token: write`), and
- `get-secretmanager-secrets` fetches a **live AlloyDB cluster password** into the job environment.

The job has **no fork gate**, while the sibling `integration` job in `tests.yaml` (same repo, same self-hosted label) carries exactly that gate:

```yaml
if: |
  github.event_name != 'pull_request' ||
  (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
```

As-is, a fork PR touching `examples/go/**` gets fork-controlled script execution on the self-hosted runner with those credentials in the environment — with zero maintainer involvement (the `changes` paths-filter gate passes on fork PRs via the workflow's own `pull-requests: write` token).

Public-run corroboration: the `go` sample job appears in the run history of fork PRs.

## The change

Applies the same gate to the `go` job, composed with the existing paths/schedule condition — fork PRs and dependabot no longer reach the privileged runner; same-repo PRs, pushes, and the scheduled run behave exactly as before.

Found during an authorized security review of the workflows; reported to Google (the repo's OSS VRP tier routes fixes here, per the VRP reply). Happy to adjust the expression if you prefer gating at workflow level.